### PR TITLE
Formatting and arrays

### DIFF
--- a/Relativty_Driver/include/Relativty_EmbeddedPython.h
+++ b/Relativty_Driver/include/Relativty_EmbeddedPython.h
@@ -5,7 +5,7 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,6 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
-#pragma warning(disable:4996)
+#pragma warning(disable : 4996)
 
 void startPythonTrackingClient_threaded(std::string PyPath);

--- a/Relativty_Driver/include/Relativty_HMDDriver.hpp
+++ b/Relativty_Driver/include/Relativty_HMDDriver.hpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
+#include <array>
 #include <thread>
 #include <atomic>
 #include <WinSock2.h>

--- a/Relativty_Driver/include/Relativty_HMDDriver.hpp
+++ b/Relativty_Driver/include/Relativty_HMDDriver.hpp
@@ -5,7 +5,7 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,9 +14,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
+
+#include <atomic>
 #include <array>
 #include <thread>
-#include <atomic>
+#include <shared_mutex>
 #include <WinSock2.h>
 #include "hidapi/hidapi.h"
 #include "openvr_driver.h"
@@ -24,11 +26,9 @@
 #include "Relativty_base_device.h"
 
 namespace Relativty {
-	class HMDDriver : public RelativtyDevice<false>
-	{
+	class HMDDriver : public RelativtyDevice<false> {
 	public:
-		HMDDriver(std::string myserial);
-		~HMDDriver() = default;
+		HMDDriver(const std::string &myserial);
 
 		void frameUpdate();
 		inline void setProperties();
@@ -49,21 +49,23 @@ namespace Relativty {
 		float HeadToEyeDepth;
 
 		vr::DriverPose_t lastPose = {0};
-		hid_device* handle;
+		hid_device *handle;
 
-		std::atomic<float> quat[4];
+		std::shared_timed_mutex quatMutex;
+		std::array<float, 4> quat = { 0.0f, 0.0f, 0.0f, 0.0f };
 		std::atomic<bool> retrieve_quaternion_isOn = false;
-		std::atomic<bool> new_quaternion_avaiable = false;
+		std::atomic<bool> new_quaternion_available = false;
 
-		std::atomic<float> qconj[4] = {1, 0, 0, 0};
+		std::array<float, 4> qconj = { 1.0f, 0.0f, 0.0f, 0.0f };
 		void calibrate_quaternion();
 
 		std::thread retrieve_quaternion_thread_worker;
 		void retrieve_device_quaternion_packet_threaded();
 
-		std::atomic<float> vector_xyz[3];
+		std::shared_timed_mutex vectorMutex;
+		std::array<float, 3> vector_xyz = { 0.0f, 0.0f, 0.0f };
 		std::atomic<bool> retrieve_vector_isOn = false;
-		std::atomic<bool> new_vector_avaiable = false;
+		std::atomic<bool> new_vector_available = false;
 		bool start_tracking_server = false;
 		SOCKET sock, sock_receive;
 		float upperBound;
@@ -95,4 +97,4 @@ namespace Relativty {
 		std::string PyPath;
 		std::thread startPythonTrackingClient_worker;
 	};
-}
+} // namespace Relativty

--- a/Relativty_Driver/include/Relativty_ServerDriver.hpp
+++ b/Relativty_Driver/include/Relativty_ServerDriver.hpp
@@ -5,7 +5,7 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#pragma once
 #ifndef RELATIVTY_SERVERDRIVER_H
 #define RELATIVTY_SERVERDRIVER_H
 
@@ -21,21 +20,21 @@
 #include "Relativty_HMDDriver.hpp"
 
 namespace Relativty {
-	class ServerDriver : public vr::IServerTrackedDeviceProvider
-	{
+	class ServerDriver : public vr::IServerTrackedDeviceProvider {
 	public:
-		virtual vr::EVRInitError Init(vr::IVRDriverContext* DriverContext) override;
+		virtual vr::EVRInitError Init(vr::IVRDriverContext *DriverContext) override;
 		virtual void Cleanup() override;
-		virtual const char* const* GetInterfaceVersions() override;
+		virtual const char *const *GetInterfaceVersions() override;
 		virtual void RunFrame() override;
 		virtual bool ShouldBlockStandbyMode() override;
 		virtual void EnterStandby() override;
 		virtual void LeaveStandby() override;
 
-		static void Log(std::string log);
+		static void Log(const std::string &log);
+
 	private:
-		HMDDriver* HMDDriver = nullptr;
+		HMDDriver *m_HMDDriver = nullptr;
 	};
-}
+} // namespace Relativty
 
 #endif // RELATIVTY_SERVERDRIVER_H

--- a/Relativty_Driver/include/Relativty_base_device.h
+++ b/Relativty_Driver/include/Relativty_base_device.h
@@ -1,45 +1,42 @@
-#pragma once
+// Copyright (C) 2020  Max Coutte, Gabriel Combe
+// Copyright (C) 2020  Relativty.com
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #ifndef VR_DEVICE_BASE_H
 #define VR_DEVICE_BASE_H
 
 #include "driverlog.h"
 
-
 #include "Relativty_components.h"
 
 namespace Relativty {
-  inline vr::HmdQuaternion_t HmdQuaternion_Init(double w, double x, double y,
-                                            double z) {
-    vr::HmdQuaternion_t quat;
-    quat.w = w;
-    quat.x = x;
-    quat.y = y;
-    quat.z = z;
-    return quat;
-  }
-
   static const char *const k_pch_Driver_Section = "driver_Relativty";
   static const char *const k_pch_Driver_PoseTimeOffset_Float = "PoseTimeOffset";
   static const char *const k_pch_Driver_UpdateUrl_String = "ManualUpdateURL";
 
-   // for now this will never signal for updates, this same function will be executed for all derived device classes on Activate
+  // for now this will never signal for updates, this same function will be executed for all derived device classes on Activate
   // you can implement your own version/update check here
   inline bool _checkForDeviceUpdates(std::string deviceSerial) {
     return false; // true steamvr will signal an update, false not
   }
 
   // should be publicly inherited
-  template<bool UseHaptics>
-  class RelativtyDevice: public vr::ITrackedDeviceServerDriver {
+  template <bool UseHaptics>
+  class RelativtyDevice : public vr::ITrackedDeviceServerDriver {
   public:
-    RelativtyDevice(std::string myserial, std::string deviceBreed): m_sSerialNumber(myserial) {
+    RelativtyDevice(const std::string &myserial, const std::string &deviceBreed) : m_unObjectId(vr::k_unTrackedDeviceIndexInvalid), m_ulPropertyContainer(vr::k_ulInvalidPropertyContainer), m_sSerialNumber(myserial), m_sModelNumber(deviceBreed + myserial) {
       // boilerplate
-
-      m_unObjectId = vr::k_unTrackedDeviceIndexInvalid;
-      m_ulPropertyContainer = vr::k_ulInvalidPropertyContainer;
-
-      m_sModelNumber = deviceBreed + m_sSerialNumber;
 
       m_fPoseTimeOffset = vr::VRSettings()->GetFloat(k_pch_Driver_Section, k_pch_Driver_PoseTimeOffset_Float);
       char buff[1024];
@@ -55,18 +52,17 @@ namespace Relativty {
       m_Pose.poseTimeOffset = (double)m_fPoseTimeOffset;
       m_Pose.poseIsValid = true;
       m_Pose.deviceIsConnected = true;
-      m_Pose.qWorldFromDriverRotation = HmdQuaternion_Init(1, 0, 0, 0);
-      m_Pose.qDriverFromHeadRotation = HmdQuaternion_Init(1, 0, 0, 0);
-      m_Pose.qRotation = HmdQuaternion_Init(1, 0, 0, 0);
+      m_Pose.qWorldFromDriverRotation = {1, 0, 0, 0};
+      m_Pose.qDriverFromHeadRotation = {1, 0, 0, 0};
+      m_Pose.qRotation = {1, 0, 0, 0};
       m_Pose.vecPosition[0] = 0.;
       m_Pose.vecPosition[1] = 0.;
       m_Pose.vecPosition[2] = 0.;
       m_Pose.willDriftInYaw = true;
     }
 
-    ~RelativtyDevice(){
+    virtual ~RelativtyDevice() {
       DriverLog("device with serial %s yeeted out of existence\n", m_sSerialNumber.c_str());
-
     }
 
     virtual vr::EVRInitError Activate(vr::TrackedDeviceIndex_t unObjectId) {
@@ -93,18 +89,18 @@ namespace Relativty {
       DriverLog("device render model: \"%s\"\n", m_sRenderModelPath.c_str());
       DriverLog("device input binding: \"%s\"\n", m_sBindPath.c_str());
 
-      if constexpr(UseHaptics) {
+      if constexpr (UseHaptics) {
         DriverLog("device haptics added\n");
         vr::VRDriverInput()->CreateHapticComponent(m_ulPropertyContainer,
-                                                       "/output/haptic", &m_compHaptic);
+                                                   "/output/haptic", &m_compHaptic);
       }
 
       vr::VRProperties()->SetBoolProperty(
           m_ulPropertyContainer, vr::Prop_Identifiable_Bool, UseHaptics);
 
       vr::VRProperties()->SetStringProperty(
-        m_ulPropertyContainer, vr::Prop_Firmware_ManualUpdateURL_String,
-        m_sUpdateUrl.c_str());
+          m_ulPropertyContainer, vr::Prop_Firmware_ManualUpdateURL_String,
+          m_sUpdateUrl.c_str());
 
       bool shouldUpdate = _checkForDeviceUpdates(m_sSerialNumber);
 
@@ -115,7 +111,6 @@ namespace Relativty {
                                           vr::Prop_Firmware_UpdateAvailable_Bool, shouldUpdate);
       vr::VRProperties()->SetBoolProperty(m_ulPropertyContainer,
                                           vr::Prop_Firmware_ManualUpdate_Bool, shouldUpdate);
-
 
       return vr::VRInitError_None;
     }
@@ -130,7 +125,7 @@ namespace Relativty {
 
     virtual void PowerOff() {}
 
-    // debug request from the client, TODO: uh... actually implement this? 
+    // debug request from the client, TODO: uh... actually implement this?
     virtual void DebugRequest(const char *pchRequest, char *pchResponseBuffer,
                               uint32_t unResponseBufferSize) {
       DriverLog("device serial \"%s\", got debug request: \"%s\"", m_sSerialNumber.c_str(), pchRequest);
@@ -143,7 +138,7 @@ namespace Relativty {
     void *GetComponent(const char *pchComponentNameAndVersion) {
       // don't touch this
       DriverLog("device serial \"%s\", got request for \"%s\" component\n", m_sSerialNumber.c_str(), pchComponentNameAndVersion);
-      if (!_stricmp(pchComponentNameAndVersion, vr::IVRDisplayComponent_Version) && m_spExtDisplayComp != nullptr){
+      if (!_stricmp(pchComponentNameAndVersion, vr::IVRDisplayComponent_Version) && m_spExtDisplayComp != nullptr) {
         DriverLog("component found, responding...\n");
         return m_spExtDisplayComp.get();
       }
@@ -156,28 +151,27 @@ namespace Relativty {
 
     // processes events, reacts to haptics only
     void ProcessEvent(const vr::VREvent_t &vrEvent) {
-      if constexpr(UseHaptics)
-      {
+      if constexpr (UseHaptics) {
         switch (vrEvent.eventType) {
-          case vr::VREvent_Input_HapticVibration: {
-            if (vrEvent.data.hapticVibration.componentHandle == m_compHaptic) {
-                // haptic!
-                DriverLog("%s haptic event: %f, %f, %f\n", m_sSerialNumber, vrEvent.data.hapticVibration.fDurationSeconds,
-                          vrEvent.data.hapticVibration.fFrequency, vrEvent.data.hapticVibration.fAmplitude);
-            }
-          } break;
+        case vr::VREvent_Input_HapticVibration: {
+          if (vrEvent.data.hapticVibration.componentHandle == m_compHaptic) {
+            // haptic!
+            DriverLog("%s haptic event: %f, %f, %f\n", m_sSerialNumber, vrEvent.data.hapticVibration.fDurationSeconds,
+                      vrEvent.data.hapticVibration.fFrequency, vrEvent.data.hapticVibration.fAmplitude);
+          }
+        }
+        break;
         }
       }
     }
 
   protected:
     // openvr api stuff
-    vr::TrackedDeviceIndex_t m_unObjectId; // DO NOT TOUCH THIS, parent will handle this, use it as read only!
+    vr::TrackedDeviceIndex_t m_unObjectId;               // DO NOT TOUCH THIS, parent will handle this, use it as read only!
     vr::PropertyContainerHandle_t m_ulPropertyContainer; // THIS EITHER, use it as read only!
 
-
     std::string m_sRenderModelPath; // path to the device's render model, should be populated in the constructor of the derived class
-    std::string m_sBindPath; // path to the device's input bindings, should be populated in the constructor of the derived class
+    std::string m_sBindPath;        // path to the device's input bindings, should be populated in the constructor of the derived class
 
     vr::DriverPose_t m_Pose; // device's pose, use this at runtime
 
@@ -185,13 +179,13 @@ namespace Relativty {
 
   private:
     // openvr api stuff that i don't trust you with
-    float m_fPoseTimeOffset; // time offset of the pose, set trough the config
+    float m_fPoseTimeOffset;                   // time offset of the pose, set trough the config
     vr::VRInputComponentHandle_t m_compHaptic; // haptics, used if UseHaptics is true
 
-    std::string m_sUpdateUrl; // url to which steamvr will redirect if checkForDeviceUpdates returns true on Activate, set trough the config
+    std::string m_sUpdateUrl;    // url to which steamvr will redirect if checkForDeviceUpdates returns true on Activate, set trough the config
     std::string m_sSerialNumber; // steamvr uses this to identify devices, no need for you to touch this after init
-    std::string m_sModelNumber; // steamvr uses this to identify devices, no need for you to touch this after init
+    std::string m_sModelNumber;  // steamvr uses this to identify devices, no need for you to touch this after init
   };
-}
+} // namespace Relativty
 
 #endif // VR_DEVICE_BASE_H

--- a/Relativty_Driver/include/Relativty_components.h
+++ b/Relativty_Driver/include/Relativty_components.h
@@ -1,4 +1,17 @@
-#pragma once
+// Copyright (C) 2020  Max Coutte, Gabriel Combe
+// Copyright (C) 2020  Relativty.com
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #ifndef RELATIVTY_COMPONENTS_H
 #define RELATIVTY_COMPONENTS_H
@@ -19,11 +32,10 @@ namespace Relativty {
   static const char *const k_pch_ExtDisplay_IsDisplayReal_Bool = "IsDisplayRealDisplay";
   static const char *const k_pch_ExtDisplay_IsDisplayOnDesktop_bool = "IsDisplayOnDesktop";
 
-
   static const bool g_bRelativtyExtDisplayComp_doLensStuff = true;
-  class RelativtyExtendedDisplayComponent: public vr::IVRDisplayComponent {
+  class RelativtyExtendedDisplayComponent : public vr::IVRDisplayComponent {
   public:
-    RelativtyExtendedDisplayComponent(){
+    RelativtyExtendedDisplayComponent() {
 
       m_nWindowX = vr::VRSettings()->GetInt32(k_pch_ExtDisplay_Section,
                                               k_pch_ExtDisplay_WindowX_Int32);
@@ -55,17 +67,16 @@ namespace Relativty {
       m_fZoomHeight = vr::VRSettings()->GetFloat(k_pch_ExtDisplay_Section,
                                                  k_pch_ExtDisplay_ZoomHeight_Float);
 
-      m_iEyeGapOff = vr::VRSettings()->GetFloat(k_pch_ExtDisplay_Section,
-                                                 k_pch_ExtDisplay_EyeGapOffset_Int);
+      m_iEyeGapOff = vr::VRSettings()->GetInt32(k_pch_ExtDisplay_Section,
+                                                k_pch_ExtDisplay_EyeGapOffset_Int);
 
       m_bIsDisplayReal = vr::VRSettings()->GetBool(k_pch_ExtDisplay_Section,
-                                                 k_pch_ExtDisplay_IsDisplayReal_Bool);
+                                                   k_pch_ExtDisplay_IsDisplayReal_Bool);
 
       m_bIsDisplayOnDesktop = vr::VRSettings()->GetBool(k_pch_ExtDisplay_Section,
-                                                 k_pch_ExtDisplay_IsDisplayOnDesktop_bool);
+                                                        k_pch_ExtDisplay_IsDisplayOnDesktop_bool);
 
-
-      #ifdef DRIVERLOG_H
+#ifdef DRIVERLOG_H
       DriverLog("Extended display component created\n");
       DriverLog("distortion koeffs: k1=%f, k2=%f\n", m_fDistortionK1, m_fDistortionK2);
       DriverLog("render target: %dx%d\n", m_nRenderWidth, m_nRenderHeight);
@@ -73,10 +84,9 @@ namespace Relativty {
       DriverLog("eye gap offset: %d", m_iEyeGapOff);
       DriverLog("is display real: %d", (int)m_bIsDisplayReal);
       DriverLog("is display on desktop: %d", (int)m_bIsDisplayOnDesktop);
-      #else
+#else
       vr::VRDriverLog()->Log("Extended display component created\n");
-      #endif
-
+#endif
     }
 
     virtual void GetWindowBounds(int32_t *pnX, int32_t *pnY, uint32_t *pnWidth,
@@ -119,10 +129,10 @@ namespace Relativty {
     }
 
     virtual vr::DistortionCoordinates_t ComputeDistortion(vr::EVREye eEye, float fU,
-                                                      float fV) {
+                                                          float fV) {
       vr::DistortionCoordinates_t coordinates;
 
-      if constexpr(g_bRelativtyExtDisplayComp_doLensStuff) {
+      if constexpr (g_bRelativtyExtDisplayComp_doLensStuff) {
         // Distortion for lens implementation from
         // https://github.com/HelenXR/openvr_survivor/blob/master/src/head_mount_display_device.cc
         float hX;
@@ -156,7 +166,7 @@ namespace Relativty {
       return coordinates;
     }
 
-    const char* GetComponentNameAndVersion() {return vr::IVRDisplayComponent_Version;}
+    const char *GetComponentNameAndVersion() { return vr::IVRDisplayComponent_Version; }
 
   private:
     int32_t m_nWindowX;
@@ -170,13 +180,12 @@ namespace Relativty {
     bool m_bIsDisplayReal;
     bool m_bIsDisplayOnDesktop;
 
-
     float m_fDistortionK1;
     float m_fDistortionK2;
     float m_fZoomWidth;
     float m_fZoomHeight;
   };
 
-}
+} // namespace Relativty
 
 #endif // RELATIVTY_COMPONENTS_H

--- a/Relativty_Driver/source/DriverFactory.cpp
+++ b/Relativty_Driver/source/DriverFactory.cpp
@@ -5,7 +5,7 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -16,14 +16,9 @@
 #include "openvr_driver.h"
 #include "Relativty_ServerDriver.hpp"
 
-
-static std::shared_ptr<Relativty::ServerDriver> Relativty_Driver;
-
-extern "C" __declspec(dllexport) void* HmdDriverFactory(const char* InterfaceName, int* ReturnCode) {
+extern "C" __declspec(dllexport) void *HmdDriverFactory(const char *InterfaceName, int *ReturnCode) {
 	if (std::strcmp(InterfaceName, vr::IServerTrackedDeviceProvider_Version) == 0) {
-		if (!Relativty_Driver) {
-			Relativty_Driver = std::make_shared<Relativty::ServerDriver>();
-		}
+		static std::shared_ptr<Relativty::ServerDriver> Relativty_Driver = std::make_shared<Relativty::ServerDriver>();
 		return Relativty_Driver.get();
 	}
 	if (ReturnCode)

--- a/Relativty_Driver/source/Relativty_EmbeddedPython.cpp
+++ b/Relativty_Driver/source/Relativty_EmbeddedPython.cpp
@@ -5,7 +5,7 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,21 +15,17 @@
 
 #pragma comment(lib, "Ws2_32.lib")
 #pragma comment(lib, "User32.lib")
-#pragma comment (lib, "Setupapi.lib")
-#pragma comment (lib, "python38.lib")
+#pragma comment(lib, "Setupapi.lib")
+#pragma comment(lib, "python38.lib")
 
-#include <iostream>
-#include <filesystem>
 #include <string>
 #include "Python.h"
 #include "Relativty_EmbeddedPython.h"
 #include "Relativty_ServerDriver.hpp"
 
-namespace fs = std::filesystem;
-
 void startPythonTrackingClient_threaded(std::string PyPath) {
 	std::string fileName = PyPath + "/Client.py";
-	FILE* fp;
+	FILE *fp;
 	fp = fopen(fileName.c_str(), "rb");
 
 	std::string singleQuote = "\'";
@@ -37,6 +33,6 @@ void startPythonTrackingClient_threaded(std::string PyPath) {
 	Py_Initialize();
 	PyRun_SimpleString(PyPath.c_str());
 	Relativty::ServerDriver::Log("Thread4: starting Client.py \n");
-	PyRun_AnyFileExFlags(fp, "Client.py", 0, NULL);
+	PyRun_AnyFileExFlags(fp, "Client.py", 0, nullptr);
 	Py_Finalize();
 }

--- a/Relativty_Driver/source/Relativty_HMDDriver.cpp
+++ b/Relativty_Driver/source/Relativty_HMDDriver.cpp
@@ -5,7 +5,7 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,10 +14,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma comment(lib, "Ws2_32.lib")
-#pragma comment (lib, "Setupapi.lib")
+#pragma comment(lib, "Setupapi.lib")
 #pragma comment(lib, "User32.lib")
 
 #include <atomic>
+#include <algorithm>
 #include <WinSock2.h>
 #include <Windows.h>
 #include "hidapi/hidapi.h"
@@ -43,20 +44,18 @@ vr::EVRInitError Relativty::HMDDriver::Activate(uint32_t unObjectId) {
 	RelativtyDevice::Activate(unObjectId);
 	this->setProperties();
 
-	int result;
-	result = hid_init(); //Result should be 0.
-	if (result) {
+	if (hid_init()) {
 		Relativty::ServerDriver::Log("USB: HID API initialization failed. \n");
 		return vr::VRInitError_Driver_TrackedDeviceInterfaceUnknown;
 	}
 
-	this->handle = hid_open((unsigned short)m_iVid, (unsigned short)m_iPid, NULL);
+	this->handle = hid_open((unsigned short)m_iVid, (unsigned short)m_iPid, nullptr);
 	if (!this->handle) {
-		#ifdef DRIVERLOG_H
+#ifdef DRIVERLOG_H
 		DriverLog("USB: Unable to open HMD device with pid=%d and vid=%d.\n", m_iPid, m_iVid);
-		#else
-		Relativty::ServerDriver::Log("USB: Unable to open HMD device with pid="+ std::to_string(m_iPid) +" and vid="+ std::to_string(m_iVid) +".\n");
-		#endif
+#else
+		Relativty::ServerDriver::Log("USB: Unable to open HMD device with pid=" + std::to_string(m_iPid) + " and vid=" + std::to_string(m_iVid) + ".\n");
+#endif
 		return vr::VRInitError_Init_InterfaceNotFound;
 	}
 
@@ -98,125 +97,80 @@ void Relativty::HMDDriver::Deactivate() {
 void Relativty::HMDDriver::update_pose_threaded() {
 	Relativty::ServerDriver::Log("Thread2: successfully started\n");
 	while (m_unObjectId != vr::k_unTrackedDeviceIndexInvalid) {
-		if (this->new_quaternion_avaiable && this->new_vector_avaiable) {
-			m_Pose.qRotation.w = this->quat[0];
-			m_Pose.qRotation.x = this->quat[1];
-			m_Pose.qRotation.y = this->quat[2];
-			m_Pose.qRotation.z = this->quat[3];
-
-			m_Pose.vecPosition[0] = this->vector_xyz[0];
-			m_Pose.vecPosition[1] = this->vector_xyz[1];
-			m_Pose.vecPosition[2] = this->vector_xyz[2];
+		if (this->new_quaternion_available && this->new_vector_available) {
+			std::shared_lock quatLock(quatMutex);
+			std::shared_lock vectorLock(vectorMutex);
+			std::copy(this->quat.begin(), this->quat.end(), reinterpret_cast<float *>(&m_Pose.qRotation));
+			std::copy(this->vector_xyz.begin(), this->vector_xyz.end(), std::begin(m_Pose.vecPosition));
 
 			vr::VRServerDriverHost()->TrackedDevicePoseUpdated(m_unObjectId, m_Pose, sizeof(vr::DriverPose_t));
-			this->new_quaternion_avaiable = false;
-			this->new_vector_avaiable = false;
-
-		} else if (this->new_quaternion_avaiable) {
-			m_Pose.qRotation.w = this->quat[0];
-			m_Pose.qRotation.x = this->quat[1];
-			m_Pose.qRotation.y = this->quat[2];
-			m_Pose.qRotation.z = this->quat[3];
+			this->new_quaternion_available = false;
+			this->new_vector_available = false;
+		} else if (this->new_quaternion_available) {
+			std::shared_lock quatLock(quatMutex);
+			std::copy(this->quat.begin(), this->quat.end(), reinterpret_cast<float *>(&m_Pose.qRotation));
 
 			vr::VRServerDriverHost()->TrackedDevicePoseUpdated(m_unObjectId, m_Pose, sizeof(vr::DriverPose_t));
-			this->new_quaternion_avaiable = false;
-
-		} else if (this->new_vector_avaiable) {
-
-			m_Pose.vecPosition[0] = this->vector_xyz[0];
-			m_Pose.vecPosition[1] = this->vector_xyz[1];
-			m_Pose.vecPosition[2] = this->vector_xyz[2];
+			this->new_quaternion_available = false;
+		} else if (this->new_vector_available) {
+			std::shared_lock vectorLock(vectorMutex);
+			std::copy(this->vector_xyz.begin(), this->vector_xyz.end(), std::begin(m_Pose.vecPosition));
 
 			vr::VRServerDriverHost()->TrackedDevicePoseUpdated(m_unObjectId, m_Pose, sizeof(vr::DriverPose_t));
-			this->new_vector_avaiable = false;
-
+			this->new_vector_available = false;
 		}
 	}
 	Relativty::ServerDriver::Log("Thread2: successfully stopped\n");
 }
 
 void Relativty::HMDDriver::calibrate_quaternion() {
+	std::lock_guard writeLock(quatMutex);
 	if ((0x01 & GetAsyncKeyState(0x52)) != 0) {
-		qconj[0].store(quat[0]);
-		qconj[1].store(-1 * quat[1]);
-		qconj[2].store(-1 * quat[2]);
-		qconj[3].store(-1 * quat[3]);
+		qconj[0] = this->quat[0];
+		qconj[1] = -1 * this->quat[1];
+		qconj[2] = -1 * this->quat[2];
+		qconj[3] = -1 * this->quat[3];
 	}
-	float qres[4];
 
-	qres[0] = qconj[0] * quat[0] - qconj[1] * quat[1] - qconj[2] * quat[2] - qconj[3] * quat[3];
-	qres[1] = qconj[0] * quat[1] + qconj[1] * quat[0] + qconj[2] * quat[3] - qconj[3] * quat[2];
-	qres[2] = qconj[0] * quat[2] - qconj[1] * quat[3] + qconj[2] * quat[0] + qconj[3] * quat[1];
-	qres[3] = qconj[0] * quat[3] + qconj[1] * quat[2] - qconj[2] * quat[1] + qconj[3] * quat[0];
-
-	this->quat[0] = qres[0];
-	this->quat[1] = qres[1];
-	this->quat[2] = qres[2];
-	this->quat[3] = qres[3];
+	this->quat[0] = qconj[0] * this->quat[0] - qconj[1] * this->quat[1] - qconj[2] * this->quat[2] - qconj[3] * this->quat[3];
+	this->quat[1] = qconj[0] * this->quat[1] + qconj[1] * this->quat[0] + qconj[2] * this->quat[3] - qconj[3] * this->quat[2];
+	this->quat[2] = qconj[0] * this->quat[2] - qconj[1] * this->quat[3] + qconj[2] * this->quat[0] + qconj[3] * this->quat[1];
+	this->quat[3] = qconj[0] * this->quat[3] + qconj[1] * this->quat[2] - qconj[2] * this->quat[1] + qconj[3] * this->quat[0];
 }
 
 void Relativty::HMDDriver::retrieve_device_quaternion_packet_threaded() {
-	uint8_t packet_buffer[64];
-	int16_t quaternion_packet[4];
-	//this struct is for mpu9250 support
-	#pragma pack(push, 1)
+	std::array<uint8_t, 64> packet_buffer;
+	std::array<int16_t, 4> quaternion_packet;
+//this struct is for mpu9250 support
+#pragma pack(push, 1)
 	struct pak {
 		uint8_t id;
-		float quat[4];
-		uint8_t rest[47];
+		std::array<float, 4> quat;
 	};
-	#pragma pack(pop)
-	int result;
+#pragma pack(pop)
 	Relativty::ServerDriver::Log("Thread1: successfully started\n");
 	while (this->retrieve_quaternion_isOn) {
-		result = hid_read(this->handle, packet_buffer, 64); //Result should be greater than 0.
-		if (result > 0) {
-
-
+		if (hid_read(this->handle, packet_buffer.data(), packet_buffer.size()) > 0) {
 			if (m_bIMUpktIsDMP) {
-
 				quaternion_packet[0] = ((packet_buffer[1] << 8) | packet_buffer[2]);
 				quaternion_packet[1] = ((packet_buffer[5] << 8) | packet_buffer[6]);
 				quaternion_packet[2] = ((packet_buffer[9] << 8) | packet_buffer[10]);
 				quaternion_packet[3] = ((packet_buffer[13] << 8) | packet_buffer[14]);
-				this->quat[0] = static_cast<float>(quaternion_packet[0]) / 16384.0f;
-				this->quat[1] = static_cast<float>(quaternion_packet[1]) / 16384.0f;
-				this->quat[2] = static_cast<float>(quaternion_packet[2]) / 16384.0f;
-				this->quat[3] = static_cast<float>(quaternion_packet[3]) / 16384.0f;
+				std::lock_guard writeLock(quatMutex);
+				std::transform(quaternion_packet.begin(), quaternion_packet.end(), this->quat.begin(), [](const int16_t &item) { return static_cast<float>(item) / 16384.0F; });
 
-				float qres[4];
-				qres[0] = quat[0];
-				qres[1] = quat[1];
-				qres[2] = -1 * quat[2];
-				qres[3] = -1 * quat[3];
-
-				this->quat[0] = qres[0];
-				this->quat[1] = qres[1];
-				this->quat[2] = qres[2];
-				this->quat[3] = qres[3];
-
-				this->calibrate_quaternion();
-
-				this->new_quaternion_avaiable = true;
-
+				this->quat[0] = quat[0];
+				this->quat[1] = quat[1];
+				this->quat[2] = -1 * quat[2];
+				this->quat[3] = -1 * quat[3];
+			} else {
+				pak *recv = reinterpret_cast<pak *>(packet_buffer.data());
+				std::lock_guard writeLock(quatMutex);
+				std::copy(recv->quat.begin(), recv->quat.end(), this->quat.begin());
 			}
-			else {
-				
-				pak* recv = (pak*)packet_buffer;
-				this->quat[0] = recv->quat[0];
-				this->quat[1] = recv->quat[1];
-				this->quat[2] = recv->quat[2];
-				this->quat[3] = recv->quat[3];
-
-				this->calibrate_quaternion();
-
-				this->new_quaternion_avaiable = true;
-
-			}
-
-
-		}
-		else {
+			this->calibrate_quaternion();
+			this->new_quaternion_available = true;
+		} else {
 			Relativty::ServerDriver::Log("Thread1: Issue while trying to read USB\n");
 		}
 	}
@@ -227,8 +181,8 @@ void Relativty::HMDDriver::retrieve_client_vector_packet_threaded() {
 	WSADATA wsaData;
 	struct sockaddr_in server, client;
 	int addressLen;
-	int receiveBufferLen = 12;
-	char receiveBuffer[12];
+	constexpr int receiveBufferLen = 12;
+	char receiveBuffer[receiveBufferLen];
 	int resultReceiveLen;
 
 	std::array<float, 3> normalize_min = {this->normalizeMinX, this->normalizeMinY, this->normalizeMinZ};
@@ -246,16 +200,20 @@ void Relativty::HMDDriver::retrieve_client_vector_packet_threaded() {
 	}
 	Relativty::ServerDriver::Log("Thread3: Socket successfully initialised.\n");
 
-	if ((this->sock = socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET)
+	if ((this->sock = socket(AF_INET, SOCK_STREAM, 0)) == INVALID_SOCKET) {
 		Relativty::ServerDriver::Log("Thread3: could not create socket: " + WSAGetLastError());
+		return;
+	}
 	Relativty::ServerDriver::Log("Thread3: Socket created.\n");
 
 	server.sin_family = AF_INET;
 	server.sin_port = htons(50000);
 	server.sin_addr.s_addr = INADDR_ANY;
 
-	if (bind(this->sock, (struct sockaddr*) & server, sizeof(server)) == SOCKET_ERROR)
+	if (bind(this->sock, (struct sockaddr *)&server, sizeof(server)) == SOCKET_ERROR) {
 		Relativty::ServerDriver::Log("Thread3: Bind failed with error code: " + WSAGetLastError());
+		return;
+	}
 	Relativty::ServerDriver::Log("Thread3: Bind done \n");
 
 	listen(this->sock, 1);
@@ -264,33 +222,35 @@ void Relativty::HMDDriver::retrieve_client_vector_packet_threaded() {
 
 	Relativty::ServerDriver::Log("Thread3: Waiting for incoming connections...\n");
 	addressLen = sizeof(struct sockaddr_in);
-	this->sock_receive = accept(this->sock, (struct sockaddr*) & client, &addressLen);
-	if (this->sock_receive == INVALID_SOCKET)
+	this->sock_receive = accept(this->sock, (struct sockaddr *)&client, &addressLen);
+	if (this->sock_receive == INVALID_SOCKET) {
 		Relativty::ServerDriver::Log("Thread3: accept failed with error code: " + WSAGetLastError());
+		return;
+	}
 	Relativty::ServerDriver::Log("Thread3: Connection accepted");
 
 	Relativty::ServerDriver::Log("Thread3: successfully started\n");
 	while (this->retrieve_vector_isOn) {
-		resultReceiveLen = recv(this->sock_receive, receiveBuffer, receiveBufferLen, NULL);
+		resultReceiveLen = recv(this->sock_receive, receiveBuffer, receiveBufferLen, 0);
 		if (resultReceiveLen > 0) {
-			coordinate[0] = *(float*)(receiveBuffer);
-			coordinate[1] = *(float*)(receiveBuffer + 4);
-			coordinate[2] = *(float*)(receiveBuffer + 8);
+			coordinate[0] = *(float *)(receiveBuffer);
+			coordinate[1] = *(float *)(receiveBuffer + 4);
+			coordinate[2] = *(float *)(receiveBuffer + 8);
 
 			Normalize(coordinate_normalized, coordinate, normalize_max, normalize_min, static_cast<int>(this->upperBound), static_cast<int>(this->lowerBound), scales_coordinate_meter, offset_coordinate);
 
 			this->vector_xyz[0] = coordinate_normalized[1];
 			this->vector_xyz[1] = coordinate_normalized[2];
 			this->vector_xyz[2] = coordinate_normalized[0];
-			this->new_vector_avaiable = true;
+			this->new_vector_available = true;
 		}
 	}
 	Relativty::ServerDriver::Log("Thread3: successfully stopped\n");
 }
 
-Relativty::HMDDriver::HMDDriver(std::string myserial):RelativtyDevice(myserial, "akira_") {
+Relativty::HMDDriver::HMDDriver(const std::string &myserial) : RelativtyDevice(myserial, "akira_") {
 	// keys for use with the settings API
-	static const char* const Relativty_hmd_section = "Relativty_hmd";
+	static const char *const Relativty_hmd_section = "Relativty_hmd";
 
 	// openvr api stuff
 	m_sRenderModelPath = "{Relativty}/rendermodels/generic_hmd";

--- a/Relativty_Driver/source/Relativty_HMDDriver.cpp
+++ b/Relativty_Driver/source/Relativty_HMDDriver.cpp
@@ -31,21 +31,11 @@
 #include "Relativty_components.h"
 #include "Relativty_base_device.h"
 
-
 #include <string>
 
-inline vr::HmdQuaternion_t HmdQuaternion_Init(double w, double x, double y, double z) {
-	vr::HmdQuaternion_t quat;
-	quat.w = w;
-	quat.x = x;
-	quat.y = y;
-	quat.z = z;
-	return quat;
-}
-
-inline void Normalize(float norma[3], float v[3], float max[3], float min[3], int up, int down, float scale[3], float offset[3]) {
-	for (int i = 0; i < 4; i++) {
-		norma[i] = (((up - down) * ((v[i] - min[i]) / (max[i] - min[i])) + down) / scale[i])+ offset[i];
+inline void Normalize(std::array<float, 3> &norma, const std::array<float, 3> &v, const std::array<float, 3> &max, const std::array<float, 3> &min, const int &up, const int &down, const std::array<float, 3> &scale, const std::array<float, 3> offset) {
+	for (int i = 0; i < 3; i++) {
+		norma[i] = (((up - down) * ((v[i] - min[i]) / (max[i] - min[i])) + down) / scale[i]) + offset[i];
 	}
 }
 
@@ -241,13 +231,13 @@ void Relativty::HMDDriver::retrieve_client_vector_packet_threaded() {
 	char receiveBuffer[12];
 	int resultReceiveLen;
 
-	float normalize_min[3]{ this->normalizeMinX, this->normalizeMinY, this->normalizeMinZ};
-	float normalize_max[3]{ this->normalizeMaxX, this->normalizeMaxY, this->normalizeMaxZ};
-	float scales_coordinate_meter[3]{ this->scalesCoordinateMeterX, this->scalesCoordinateMeterY, this->scalesCoordinateMeterZ};
-	float offset_coordinate[3] = { this->offsetCoordinateX, this->offsetCoordinateY, this->offsetCoordinateZ};
+	std::array<float, 3> normalize_min = {this->normalizeMinX, this->normalizeMinY, this->normalizeMinZ};
+	std::array<float, 3> normalize_max = {this->normalizeMaxX, this->normalizeMaxY, this->normalizeMaxZ};
+	std::array<float, 3> scales_coordinate_meter = {this->scalesCoordinateMeterX, this->scalesCoordinateMeterY, this->scalesCoordinateMeterZ};
+	std::array<float, 3> offset_coordinate = {this->offsetCoordinateX, this->offsetCoordinateY, this->offsetCoordinateZ};
 
-	float coordinate[3]{ 0, 0, 0 };
-	float coordinate_normalized[3];
+	std::array<float, 3> coordinate = {0, 0, 0};
+	std::array<float, 3> coordinate_normalized;
 
 	Relativty::ServerDriver::Log("Thread3: Initialising Socket.\n");
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
@@ -287,7 +277,7 @@ void Relativty::HMDDriver::retrieve_client_vector_packet_threaded() {
 			coordinate[1] = *(float*)(receiveBuffer + 4);
 			coordinate[2] = *(float*)(receiveBuffer + 8);
 
-			Normalize(coordinate_normalized, coordinate, normalize_max, normalize_min, this->upperBound, this->lowerBound, scales_coordinate_meter, offset_coordinate);
+			Normalize(coordinate_normalized, coordinate, normalize_max, normalize_min, static_cast<int>(this->upperBound), static_cast<int>(this->lowerBound), scales_coordinate_meter, offset_coordinate);
 
 			this->vector_xyz[0] = coordinate_normalized[1];
 			this->vector_xyz[1] = coordinate_normalized[2];

--- a/Relativty_Driver/source/Relativty_ServerDriver.cpp
+++ b/Relativty_Driver/source/Relativty_ServerDriver.cpp
@@ -5,7 +5,7 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -20,41 +20,39 @@
 #include "Relativty_ServerDriver.hpp"
 #include "Relativty_HMDDriver.hpp"
 
-vr::EVRInitError Relativty::ServerDriver::Init(vr::IVRDriverContext* DriverContext) {
-
-	vr::EVRInitError eError = vr::InitServerDriverContext(DriverContext);
-		if (eError != vr::VRInitError_None) {
-			return eError;
+vr::EVRInitError Relativty::ServerDriver::Init(vr::IVRDriverContext *DriverContext) {
+	if (vr::EVRInitError eError = vr::InitServerDriverContext(DriverContext); eError != vr::VRInitError_None) {
+		return eError;
 	}
-	#ifdef DRIVERLOG_H
+#ifdef DRIVERLOG_H
 	InitDriverLog(vr::VRDriverLog());
 	DriverLog("Relativty driver version 0.1.1"); // report driver version
 	DriverLog("Thread1: hid quaternion packet listener loop");
 	DriverLog("Thread2: update driver pose loop");
 	DriverLog("Thread3: receive positional data from python loop");
-	#endif
+#endif
 
-	this->Log("Relativty Init successful.\n");
-	
-	this->HMDDriver = new Relativty::HMDDriver("zero");
-	vr::VRServerDriverHost()->TrackedDeviceAdded(HMDDriver->GetSerialNumber().c_str(), vr::ETrackedDeviceClass::TrackedDeviceClass_HMD, this->HMDDriver);
+	Relativty::ServerDriver::Log("Relativty Init successful.\n");
+
+	this->m_HMDDriver = new Relativty::HMDDriver("zero");
+	vr::VRServerDriverHost()->TrackedDeviceAdded(this->m_HMDDriver->GetSerialNumber().c_str(), vr::ETrackedDeviceClass::TrackedDeviceClass_HMD, this->m_HMDDriver);
 	// GetSerialNumber() is there for a reason!
 
 	return vr::VRInitError_None;
 }
 
 void Relativty::ServerDriver::Cleanup() {
-	delete this->HMDDriver;
-	this->HMDDriver = NULL;
+	delete this->m_HMDDriver;
+	this->m_HMDDriver = nullptr;
 
-	#ifdef DRIVERLOG_H
+#ifdef DRIVERLOG_H
 	CleanupDriverLog();
-	#endif
+#endif
 
-	VR_CLEANUP_SERVER_DRIVER_CONTEXT();
+	vr::CleanupDriverContext();
 }
 
-const char* const* Relativty::ServerDriver::GetInterfaceVersions() {
+const char *const *Relativty::ServerDriver::GetInterfaceVersions() {
 	return vr::k_InterfaceVersions;
 }
 
@@ -65,13 +63,11 @@ bool Relativty::ServerDriver::ShouldBlockStandbyMode() {
 }
 
 void Relativty::ServerDriver::EnterStandby() {
-
 }
 
 void Relativty::ServerDriver::LeaveStandby() {
-
 }
 
-void Relativty::ServerDriver::Log(std::string log) {
+void Relativty::ServerDriver::Log(const std::string &log) {
 	vr::VRDriverLog()->Log(log.c_str());
 }


### PR DESCRIPTION
# Notable fixes

## Fixed array out-of-range in `Normalize`

In `Normalize` an attempt is made te read index 3 of a c-array of length 3

## Replaced the c-arrays of `std::atomic<float>` with `std::array<float>` guarded by locks

With how the quaternions were copied, race conditions were still possible. Especially in `Relativty::HMDDriver::calibrate_quaternion`.
`Relativty::HMDDriver::qconj` was only written to in `Relativty::HMDDriver::calibrate_quaternion`, so locking that is a waste.

## Replaced assignments to quaternion arrays with `std::copy`s and a `std::transform`

The compiler can optionally optimise `std::copy`s to `memcpy`s or vector operations.

## Replaced calls to `Relativty::HmdQuaternion_Init` with braced initialization

## Rename `Relativty::ServerDriver::HMDDriver` to `m_HMDDriver`

The distinction between the class and the instance couldn't be made otherwise. No idea how MSVC handled that...

## Replaced `NULL`s with either `nullptr`s or `0`s

Some `NULL`s imply the arguments are pointers when they are `int`s

## Various formatting changes and renamed `Relativty::HMDDriver::new_vector_avaiable` to `Relativty::HMDDriver::new_vector_available`
