### PR TITLE
README: Fix wrong terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <h3 align="center">
-	Open-source VR headset with SteamVR support.
+	Technoliberal VR headset with SteamVR support.
 </h3>
 <p align="center">
 	<strong>
@@ -21,7 +21,7 @@ I’m <a href="https://twitter.com/maxim_xyz?lang=en">Maxim xyz</a> and when my 
 
 5 years later : this headset became Relativty.
 
-* Fully Open-source - **hardware**, **software**, **firmware**.
+* GPLv3-compatible - **Free hardware Design**, **Free Software**, **Free Firmware**.
 * **Steam VR** support.
 * Natively displays **2K** resolution at **120FPS**.
 * Compatible with **Arduino**.


### PR DESCRIPTION
By using "Open-source" you are implying that this design is not complying with GPLv3 meaning that it restricts the right to use, study, improve and share.

This replaces the wrong terminology with the terminology used by Free Software Foundation ("FSF").

NOTE: FSF is not using the term `Technoliberal` (https://en.wikipedia.org/wiki/Technoliberalism), it's used in the EU politics to clarify that "Free Software" is not "Socialist Software" as people get confused with the understanding of "Free" as in Freedom instead of "Gratis".
NOTE: FSF uses the term `Free Hardware Designs` instead of `Free Hardware` to make the term more understandable by the public [https://gnu.org/philosophy/free-hardware-designs.html]