### PR TITLE
README: Clarify lens type

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ We've used parts from Aliexpress:
 
 - <a href="https://www.aliexpress.com/item/33058848848.html">The Strap</a>, 
 - <a href="https://www.aliexpress.com/item/4000199486058.html">The Foam</a>,
-- <a href="https://www.aliexpress.com/item/33029909783.html">The Lenses</a> (40mm diameter/50mm focal length).
+- <a href="https://www.aliexpress.com/item/33029909783.html">The Lenses</a> (Negative Menuscus - 40mm diameter/50mm focal length).
 
 ### The screen for the HMD
 <p align="center"> <img src="ressources/img/display.jpg"> </p>


### PR DESCRIPTION
The aliexpress listing lists (assumed) "negative menuscus" lenses as "fresnel lenses", this is to avoid confusion.

Difference in lens types:
https://en.wikipedia.org/wiki/Lens#Types_of_simple_lenses